### PR TITLE
Re-submit MS-VERSS_SharePointServer2013_SHOULDMAY.deployment

### DIFF
--- a/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2013_SHOULDMAY.deployment.ptfconfig
+++ b/SharePoint/Source/MS-VERSS/TestSuite/MS-VERSS_SharePointServer2013_SHOULDMAY.deployment.ptfconfig
@@ -1,4 +1,4 @@
-f<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <TestSite xmlns="http://schemas.microsoft.com/windows/ProtocolsTest/2007/07/TestConfig"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 


### PR DESCRIPTION
Remove the typo 'f' in 2013_ptfconfig file. Please help to review it.